### PR TITLE
fixes for ja3 hack to capture tls fingerprint from client hello w/ OpenSSL 1.1.x

### DIFF
--- a/src/evr/evr_select.cc
+++ b/src/evr/evr_select.cc
@@ -156,10 +156,10 @@ int evr_select::mod(int a_fd, uint32_t a_attr_mask, evr_fd_t *a_evr_fd_event)
         FD_CLR(a_fd, &m_wfdset);
         FD_CLR(a_fd, &m_rfdset);
         if(a_attr_mask & EVR_FILE_ATTR_MASK_READ)         { FD_SET(a_fd, &m_rfdset); }
-        if(a_attr_mask & EVR_FILE_ATTR_MASK_WRITE)        { FD_SET(a_fd, &m_wfdset); }
         if(a_attr_mask & EVR_FILE_ATTR_MASK_RD_HUP)       { FD_SET(a_fd, &m_rfdset); }
         if(a_attr_mask & EVR_FILE_ATTR_MASK_HUP)          { FD_SET(a_fd, &m_rfdset); }
         if(a_attr_mask & EVR_FILE_ATTR_MASK_STATUS_ERROR) { FD_SET(a_fd, &m_rfdset); }
+        if(a_attr_mask & EVR_FILE_ATTR_MASK_WRITE)        { FD_SET(a_fd, &m_wfdset); }
         return STATUS_OK;
 }
 //! ----------------------------------------------------------------------------

--- a/src/support/ja3.cc
+++ b/src/support/ja3.cc
@@ -200,17 +200,24 @@ int32_t ja3::extract_bytes(const char* a_buf, uint16_t a_len)
         }
 #define _TLS_HANDSHAKE_RECORD 0x16
 #define _TLS_CLIENT_HELLO     0x01
-        if (((uint16_t)(a_buf[0]) != _TLS_HANDSHAKE_RECORD) ||
-            ((uint16_t)(a_buf[5]) != _TLS_CLIENT_HELLO))
-        {
+        uint16_t l_idx = 0;
+        while (l_idx < a_len) {
+                if (((uint16_t)(a_buf[l_idx]) == _TLS_HANDSHAKE_RECORD) &&
+                    ((uint16_t)(a_buf[l_idx+5]) == _TLS_CLIENT_HELLO))
+                {
+                        break;
+                }
+                ++l_idx;
+        }
+        if (l_idx >= a_len) {
                 return STATUS_OK;
         }
         // -------------------------------------------------
         // extract
         // -------------------------------------------------
-        const char* l_cur = a_buf;
-        uint16_t l_read = 0;
-        int32_t l_left = a_len;
+        const char* l_cur = a_buf+l_idx;
+        uint16_t l_read = l_idx;
+        int32_t l_left = a_len-l_idx;
         // -------------------------------------------------
         // *************************************************
         // record header


### PR DESCRIPTION
### What
- slide forward in `MSG_PEEK` buffer up to N bytes (512) to find TLS Hello Record from client handshake.