### PR TITLE
support building with GCC 13 & drop old OSs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-20.04, ubuntu-18.04, macos-latest]
+        os: [ubuntu-24.04, ubuntu-22.04, ubuntu-20.04, ubuntu-18.04, macos-12]
       fail-fast: false
 
     runs-on: ${{ matrix.os }}
@@ -23,7 +23,7 @@ jobs:
         fetch-depth: 0
 
     - name: Install Ubuntu 22 dependencies
-      if: matrix.os == 'ubuntu-22.04'
+      if: matrix.os == 'ubuntu-22.04' || matrix.os == 'ubuntu-24.04'
       run: |
         sudo apt-get update
         sudo apt-get install -y libunwind-dev libgoogle-perftools-dev rapidjson-dev
@@ -35,7 +35,7 @@ jobs:
         sudo apt-get install -y libgoogle-perftools-dev rapidjson-dev
 
     - name: Install macOS dependencies
-      if: matrix.os == 'macos-latest'
+      if: matrix.os == 'macos-12'
       run: |
         brew install cmake gperftools dpkg rapidjson
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-24.04, ubuntu-22.04, ubuntu-20.04, macos-12]
+        os: [ubuntu-24.04, ubuntu-22.04, ubuntu-20.04]
       fail-fast: false
 
     runs-on: ${{ matrix.os }}
@@ -33,11 +33,6 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y libgoogle-perftools-dev rapidjson-dev
-
-    - name: Install macOS dependencies
-      if: matrix.os == 'macos-12'
-      run: |
-        brew install cmake gperftools dpkg rapidjson
 
     - name: Run build script
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-24.04, ubuntu-22.04, ubuntu-20.04, ubuntu-18.04, macos-12]
+        os: [ubuntu-24.04, ubuntu-22.04, ubuntu-20.04, macos-12]
       fail-fast: false
 
     runs-on: ${{ matrix.os }}
@@ -28,8 +28,8 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y libunwind-dev libgoogle-perftools-dev rapidjson-dev
 
-    - name: Install Ubuntu 20/18 dependencies
-      if: matrix.os == 'ubuntu-20.04' || matrix.os == 'ubuntu-18.04'
+    - name: Install Ubuntu 20 dependencies
+      if: matrix.os == 'ubuntu-20.04'
       run: |
         sudo apt-get update
         sudo apt-get install -y libgoogle-perftools-dev rapidjson-dev

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   build:
+    timeout-minutes: 30
     strategy:
       matrix:
         os: [ubuntu-24.04, ubuntu-22.04, ubuntu-20.04]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,22 +55,6 @@ if(BUILD_TLS)
   add_definitions(-DBUILD_TLS_WITH_OPENSSL=1)
 endif()
 # ------------------------------------------------------------------------------
-# OS X specific code
-# ------------------------------------------------------------------------------
-IF(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-   SET(OperatingSystem "Mac OS X")
-   INCLUDE_DIRECTORIES(/usr/local/opt/rapidjson/include)
-   # Add MacPorts
-   if(BUILD_TLS)
-     INCLUDE_DIRECTORIES(/usr/local/opt/openssl/include)
-     LINK_DIRECTORIES(/usr/local/opt/openssl/lib)
-   endif()
-   if(BUILD_TCMALLOC OR BUILD_PROFILER)
-     INCLUDE_DIRECTORIES(/usr/local/opt/gperftools/include)
-     LINK_DIRECTORIES(/usr/local/opt/gperftools/lib)
-   endif()
-ENDIF(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-# ------------------------------------------------------------------------------
 # fortify options
 # ------------------------------------------------------------------------------
 if (FORTIFY)

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Reactor loop psuedo code:
 
 ## Install
 
-### Build requirements (tested on Ubuntu 18.04/20.04)
+### Build requirements
 
 #### Packages
 - openssl

--- a/include/is2/srvr/access.h
+++ b/include/is2/srvr/access.h
@@ -14,6 +14,7 @@
 //! ----------------------------------------------------------------------------
 #include "is2/nconn/scheme.h"
 #include "is2/srvr/http_status.h"
+#include <cstdint>
 #include <sys/socket.h>
 #include <string>
 namespace ns_is2 {


### PR DESCRIPTION
tested with `CC=gcc-13 CXX=g++-13 ./build.sh`

fixes errors like:
```
In file included from src/srvr/access.cc:13:
include/is2/srvr/access.h:41:9: error: 'uint8_t' does not name a type
   41 |         uint8_t m_rqst_http_major;
      |         ^~~~~~~
include/is2/srvr/access.h:19:1: note: 'uint8_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
   18 | #include <string>
  +++ |+#include <cstdint>
   19 | namespace ns_is2 {
```